### PR TITLE
minLength and maxLength were not added to the generated JSON schema

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/v1/PropertyWrapper.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/PropertyWrapper.java
@@ -277,10 +277,10 @@ public class PropertyWrapper extends SchemaWrapper {
                 node.put("multipleOf", attributes.multipleOf());
             }
             if (attributes.minLength() > 0) {
-                node.put("minLength", attributes.minItems());
+                node.put("minLength", attributes.minLength());
             }
             if (attributes.maxLength() > -1) {
-                node.put("maxLength", attributes.maxItems());
+                node.put("maxLength", attributes.maxLength());
             }
             if (attributes.required()) {
                 setRequired(true);

--- a/src/test/java/com/github/reinert/jjschema/v1/EmployeeTest.java
+++ b/src/test/java/com/github/reinert/jjschema/v1/EmployeeTest.java
@@ -1,0 +1,53 @@
+package com.github.reinert.jjschema.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.reinert.jjschema.Attributes;
+import com.github.reinert.jjschema.exception.UnavailableVersion;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class EmployeeTest extends TestCase {
+  private final ObjectMapper MAPPER = new ObjectMapper();
+
+  static class Employee {
+    @Attributes(required = true, minLength = 5, maxLength = 50, description = "Name")
+    private String name;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+
+  JsonSchemaFactory schemaFactory = new JsonSchemaV4Factory();
+
+  {
+    schemaFactory.setAutoPutDollarSchema(true);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes", "serial"})
+  public void testEmployeeSchema() throws UnavailableVersion, IOException {
+    JsonNode employeeSchema = schemaFactory.createSchema(Employee.class);
+    String str = MAPPER.writeValueAsString(employeeSchema);
+    Map<String, Object> result = (Map<String, Object>) MAPPER.readValue(str, Map.class);
+    assertNotNull(result);
+    assertEquals("object", result.get("type"));
+    assertNotNull(result.get("required"));
+    List required = (List) result.get("required");
+    assertEquals("name", required.get(0));
+    assertNotNull(result.get("properties"));
+    Map properties = (Map) ((Map) result.get("properties")).get("name");
+    assertEquals("string", properties.get("type"));
+    assertEquals("Name", properties.get("description"));
+    assertEquals(5, properties.get("minLength"));
+    assertEquals(50, properties.get("maxLength"));
+  }
+
+}


### PR DESCRIPTION
minLength and maxLength attributes are now correctly generated in the schema.
