### PR TITLE
Fixed a NPE in Schema generation

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
@@ -409,7 +409,7 @@ public abstract class JsonSchemaGenerator {
      */
     protected <T> ObjectNode mergeWithParent(Class<T> type, ObjectNode schema) {
         Class<? super T> superclass = type.getSuperclass();
-        if (superclass != Object.class) {
+        if (superclass != null && superclass != Object.class) {
             ObjectNode parentSchema = generateSchema(superclass);
             schema = mergeSchema(parentSchema, schema, false);
         }


### PR DESCRIPTION
Schema generation fails with NullPointerException when generating
schema from java classes containing java.net.URL fields. Below is the
code snippet to reproduce the issue.

JsonSchemaGenerator v4generator =
SchemaGeneratorBuilder.draftV4Schema().build();
JsonNode schema = v4generator.generateSchema(java.net.URL.class);

Initial investigation reveals a missing null check in mergeWithParent()
method of the JsonSchemaGenerator class. The superclass for
Object.class is null and hence NullPointerException occurs in the
subsequent if block. Adding a null check on superclass in the if
condition solves the issue. Below is the corrected snippet.

if (superclass != null && superclass != Object.class)
