### PR TITLE
Update JsonSchemaGeneratorV4.java (minLength & maxLength)

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
@@ -85,10 +85,10 @@ public class JsonSchemaGeneratorV4 extends JsonSchemaGenerator {
             schema.put("multipleOf", props.multipleOf());
         }
         if (props.minLength() > 0) {
-            schema.put("minLength", props.minItems());
+            schema.put("minLength", props.minLength());
         }
         if (props.maxLength() > -1) {
-            schema.put("maxLength", props.maxItems());
+            schema.put("maxLength", props.maxLength());
         }
     }
 


### PR DESCRIPTION
Hello Danilo,

I am using JJSchema and I have found a bug in file "JsonSchemaGeneratorV4.java":

if (props.minLength() > 0) {
schema.put("minLength", props.minItems());
}
if (props.maxLength() > -1) {
schema.put("maxLength", props.maxItems());
}

As you can see, when you put the properties minLength and maxLength in the schema, you are using minItems and maxItems instead the correct properties.

I have seen that you correct the same bug in file "PropertyWrapper.java" so I think it works in v1 but not in v4.

Best regards, Eduardo.
