### PR TITLE
Fixed bug when generating min and max length constraints

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
@@ -85,10 +85,10 @@ public class JsonSchemaGeneratorV4 extends JsonSchemaGenerator {
             schema.put("multipleOf", props.multipleOf());
         }
         if (props.minLength() > 0) {
-            schema.put("minLength", props.minItems());
+            schema.put("minLength", props.minLength());
         }
         if (props.maxLength() > -1) {
-            schema.put("maxLength", props.maxItems());
+            schema.put("maxLength", props.maxLength());
         }
     }
 


### PR DESCRIPTION
The JsonSchemaGeneratorV4.java class does not generate the minLength and maxLength constraints in the schema correctly. The schema generation code has a bug that incorrectly maps the minItems and maxItems constraints to minLength and maxLength properties. Perhaps, this was an unindented copy paste error. Fixing the same