### PR TITLE
Adding support for UUIDs as json-schema-validator expects them

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/Attributes.java
+++ b/src/main/java/com/github/reinert/jjschema/Attributes.java
@@ -49,6 +49,8 @@ public @interface Attributes {
 
     String pattern() default "";
 
+    String format() default "";
+
     boolean required() default false;
 
     String[] enums() default {};

--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
@@ -50,6 +50,9 @@ public class JsonSchemaGeneratorV4 extends JsonSchemaGenerator {
         if (!props.pattern().isEmpty()) {
             schema.put("pattern", props.pattern());
         }
+        if (!props.format().isEmpty()) {
+            schema.put("format", props.format());
+        }
         if (!props.title().isEmpty()) {
             schema.put("title", props.title());
         }

--- a/src/main/java/com/github/reinert/jjschema/SimpleTypeMappings.java
+++ b/src/main/java/com/github/reinert/jjschema/SimpleTypeMappings.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
 import java.util.AbstractCollection;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Mapping of builtin Java types to their matching JSON Schema primitive type
@@ -53,7 +54,8 @@ public enum SimpleTypeMappings {
     PRIMITIVE_CHAR(char.class, "string"),
     CHAR(Character.class, "string"),
     CHARSEQUENCE(CharSequence.class, "string"),
-    STRING(String.class, "string");
+    STRING(String.class, "string"),
+    UUID(UUID.class, "string");
 
     private static final Map<Class<?>, String> MAPPINGS;
 


### PR DESCRIPTION
JJSchema creates UUIDs as type Object with least/mostSignificantBits.  json-schema-validator expects them with a "format" property equal to "uuid" and as type String.  My updates allow users to specify the format property in the @Attributes annotation and UUID is represented in the resultant schema as a String.