### PR TITLE
Support readonly designator (for Angular Schema Form)

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/Attributes.java
+++ b/src/main/java/com/github/reinert/jjschema/Attributes.java
@@ -66,4 +66,6 @@ public @interface Attributes {
     int minLength() default 0;
 
     long maxLength() default -1l;
+    
+    boolean readonly() default false;
 }

--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGeneratorV4.java
@@ -93,6 +93,9 @@ public class JsonSchemaGeneratorV4 extends JsonSchemaGenerator {
         if (props.maxLength() > -1) {
             schema.put("maxLength", props.maxLength());
         }
+        if (props.readonly()) {
+            schema.put("readonly", true);
+        }
     }
 
 }

--- a/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
@@ -256,6 +256,9 @@ public class CustomSchemaWrapper extends SchemaWrapper implements Iterable<Prope
             if (attributes.required()) {
                 setRequired(true);
             }
+            if (attributes.readonly()) {
+            	node.put("readonly", attributes.readonly());
+            }
         }
     }
 }

--- a/src/main/java/com/github/reinert/jjschema/v1/PropertyWrapper.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/PropertyWrapper.java
@@ -308,6 +308,9 @@ public class PropertyWrapper extends SchemaWrapper {
             if (attributes.required()) {
                 setRequired(true);
             }
+            if (attributes.readonly()) {
+                node.put("readonly", true);
+            }
         }
     }
 


### PR DESCRIPTION
The PR simply adds readonly to the attributes so that it can be applied to the json schema output