### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/SchemaGeneratorBuilder.java
+++ b/src/main/java/com/github/reinert/jjschema/SchemaGeneratorBuilder.java
@@ -25,6 +25,8 @@ package com.github.reinert.jjschema;
  * @author reinert
  */
 public class SchemaGeneratorBuilder {
+    
+    private SchemaGeneratorBuilder() {}
 
     public static ConfigurationStep draftV4Schema() {
         return new ConfigurationStep(new JsonSchemaGeneratorV4());

--- a/src/main/java/com/github/reinert/jjschema/v1/SchemaWrapperFactory.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/SchemaWrapperFactory.java
@@ -32,6 +32,8 @@ import java.util.Set;
 public class SchemaWrapperFactory {
 
     public static ObjectMapper MAPPER = new ObjectMapper();
+    
+    private SchemaWrapperFactory() {}
 
     public static SchemaWrapper createWrapper(Class<?> type) {
         return createWrapper(type, null);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed