### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality.

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/HyperSchemaGeneratorV4.java
+++ b/src/main/java/com/github/reinert/jjschema/HyperSchemaGeneratorV4.java
@@ -241,7 +241,7 @@ public class HyperSchemaGeneratorV4 extends JsonSchemaGenerator {
         for (Method method : type.getDeclaredMethods()) {
             try {
                 ObjectNode link = generateLink(method);
-                if (link.get("method").asText().equals("GET") && link.get("href").asText().equals("#")) {
+                if ("GET".equals(link.get("method").asText()) && "#".equals(link.get("href").asText())) {
                     jsonSchemaGenerator.mergeSchema(schema, (ObjectNode) link.get("targetSchema"), true);
                 } else {
                     links.add(link);
@@ -293,7 +293,7 @@ public class HyperSchemaGeneratorV4 extends JsonSchemaGenerator {
         } else {
             ObjectNode jsonSchema = (ObjectNode) jsonSchemaGenerator.generateSchema(type);
             if (jsonSchema != null) {
-                if (jsonSchema.get("type").asText().equals("array")) {
+                if ("array".equals(jsonSchema.get("type").asText())) {
                     if (!Collection.class.isAssignableFrom(type)) {
                         ObjectNode items = (ObjectNode) jsonSchema.get("items");
                         // NOTE: Customized Iterable Class must declare the Collection object at first

--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
@@ -438,7 +438,7 @@ public abstract class JsonSchemaGenerator {
 
             while (namesIterator.hasNext()) {
                 String propertyName = namesIterator.next();
-                if (!propertyName.equals("properties")) {
+                if (!"properties".equals(propertyName)) {
                     overwriteProperty(parent, child, propertyName);
                 }
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Faisal Hameed