### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
@@ -44,6 +44,9 @@ public abstract class JsonSchemaGenerator {
     boolean autoPutVersion = true;
     private Set<ManagedReference> forwardReferences;
     private Set<ManagedReference> backReferences;
+    
+    protected JsonSchemaGenerator() {
+    }
 
     Set<ManagedReference> getForwardReferences() {
         if (forwardReferences == null)
@@ -96,8 +99,6 @@ public abstract class JsonSchemaGenerator {
         return createInstance().put("$ref", ref);
     }
 
-    protected JsonSchemaGenerator() {
-    }
 
     /**
      * Reads {@link Attributes} annotation and put its values into the
@@ -279,8 +280,7 @@ public abstract class JsonSchemaGenerator {
 
     protected <T> ObjectNode generatePropertySchema(Class<T> type, Method method, Field field) {
         Class<?> returnType = method.getReturnType();
-        AccessibleObject propertyReflection =
-                (AccessibleObject) field != null ? field : method;
+        AccessibleObject propertyReflection = field != null ? field : method;
 
         SchemaIgnore ignoreAnn = propertyReflection.getAnnotation(SchemaIgnore.class);
         if (ignoreAnn != null)

--- a/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * @author Danilo Reinert
@@ -130,8 +131,9 @@ public class CustomSchemaWrapper extends SchemaWrapper implements Iterable<Prope
 
     protected void processProperties() {
         HashMap<Method, Field> properties = findProperties();
-        for (Method method : properties.keySet()) {
-            PropertyWrapper propertyWrapper = new PropertyWrapper(this, managedReferences, method, properties.get(method));
+        for (Entry<Method, Field> prop : properties.entrySet()) {
+            PropertyWrapper propertyWrapper = new PropertyWrapper(this, managedReferences, 
+                    prop.getKey(), prop.getValue());
             if (!propertyWrapper.isEmptyWrapper())
                 addProperty(propertyWrapper);
         }

--- a/src/main/java/com/github/reinert/jjschema/v1/PropertyWrapper.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/PropertyWrapper.java
@@ -243,10 +243,8 @@ public class PropertyWrapper extends SchemaWrapper {
 
     protected String processId(Class<?> accessibleObject) {
         final Attributes attributes = accessibleObject.getAnnotation(Attributes.class);
-        if (attributes != null) {
-            if (!attributes.id().isEmpty()) {
-                return attributes.id();
-            }
+        if (attributes != null && !attributes.id().isEmpty()) {
+            return attributes.id();
         }
         return null;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1905 - Redundant casts should not be used
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S1066 - Collapsible "if" statements should be merged. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1066

Please let me know if you have any questions.

Faisal Hameed