### PR TITLE
Processing fields instead of getters and controlling sort order

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/HyperSchemaGeneratorV4.java
+++ b/src/main/java/com/github/reinert/jjschema/HyperSchemaGeneratorV4.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.github.reinert.jjschema.exception.InvalidLinkMethod;
+import com.github.reinert.jjschema.exception.TypeException;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
@@ -50,7 +51,7 @@ public class HyperSchemaGeneratorV4 extends JsonSchemaGenerator {
         this.jsonSchemaGenerator = jsonSchemaGenerator;
     }
 
-    private ObjectNode generateLink(Method method) throws InvalidLinkMethod {
+    private ObjectNode generateLink(Method method) throws InvalidLinkMethod, TypeException {
         String href = null, rel = null, httpMethod = null;
         boolean isLink = false;
 
@@ -213,7 +214,7 @@ public class HyperSchemaGeneratorV4 extends JsonSchemaGenerator {
         return link;
     }
 
-    private <T> ObjectNode generateHyperSchemaFromResource(Class<T> type) {
+    private <T> ObjectNode generateHyperSchemaFromResource(Class<T> type) throws TypeException  {
         ObjectNode schema = null;
 
         Annotation[] ans = type.getAnnotations();
@@ -288,7 +289,7 @@ public class HyperSchemaGeneratorV4 extends JsonSchemaGenerator {
     }
 
     @Override
-    public <T> ObjectNode generateSchema(Class<T> type) {
+    public <T> ObjectNode generateSchema(Class<T> type) throws TypeException {
         ObjectNode hyperSchema = null;
         Annotation path = type.getAnnotation(Path.class);
         if (path != null) {

--- a/src/main/java/com/github/reinert/jjschema/SchemaGeneratorBuilder.java
+++ b/src/main/java/com/github/reinert/jjschema/SchemaGeneratorBuilder.java
@@ -48,6 +48,21 @@ public class SchemaGeneratorBuilder {
             return this;
         }
 
+        public ConfigurationStep sortProperties(boolean sortProperties) {
+            generator.sortProperties = sortProperties;
+            return this;
+        }
+        
+        public ConfigurationStep processAnnotatedOnly(boolean processAnnotatedOnly) {
+            generator.processAnnotatedOnly = processAnnotatedOnly;
+            return this;
+        }
+        
+        public ConfigurationStep processFieldsOnly(boolean processFieldsOnly) {
+            generator.processFieldsOnly = processFieldsOnly;
+            return this;
+        }
+        
         public final JsonSchemaGenerator build() {
             return generator;
         }

--- a/src/main/java/com/github/reinert/jjschema/exception/TypeException.java
+++ b/src/main/java/com/github/reinert/jjschema/exception/TypeException.java
@@ -1,0 +1,13 @@
+package com.github.reinert.jjschema.exception;
+
+public class TypeException extends Exception {
+
+    private static final long serialVersionUID = 7146537640173260077L;
+
+    public TypeException() {
+    }
+
+    public TypeException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
@@ -35,8 +35,8 @@ import java.util.Map.Entry;
 
 public class CustomSchemaWrapper extends SchemaWrapper implements Iterable<PropertyWrapper> {
 
-    private static final String TAG_REQUIRED = "required";
-    private static final String TAG_PROPERTIES = "properties";
+    public static final String TAG_REQUIRED = "required";
+    public static final String TAG_PROPERTIES = "properties";
     
     private final List<PropertyWrapper> propertyWrappers;
     private boolean required;

--- a/src/test/java/com/github/reinert/jjschema/JavaRESTfulTest.java
+++ b/src/test/java/com/github/reinert/jjschema/JavaRESTfulTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.github.reinert.jjschema.exception.TypeException;
 import com.github.reinert.jjschema.model.User;
 import com.github.reinert.jjschema.rest.UserResource;
 import junit.framework.TestCase;
@@ -32,7 +33,7 @@ public class JavaRESTfulTest extends TestCase {
     ObjectWriter om = new ObjectMapper().writerWithDefaultPrettyPrinter();
     JsonSchemaGenerator v4hyperGenerator = SchemaGeneratorBuilder.draftV4HyperSchema().setAutoPutSchemaVersion(false).build();
 
-    public void testHyperSchema() throws JsonProcessingException {
+    public void testHyperSchema() throws JsonProcessingException, TypeException  {
         JsonNode userHyperSchema = v4hyperGenerator.generateSchema(User.class);
         //System.out.println(om.writeValueAsString(userSchema));
         assertEquals("image/jpg", userHyperSchema.get("properties").get("photo").get("mediaType").asText());

--- a/src/test/java/com/github/reinert/jjschema/v1/FieldsOnlyTest.java
+++ b/src/test/java/com/github/reinert/jjschema/v1/FieldsOnlyTest.java
@@ -1,0 +1,92 @@
+package com.github.reinert.jjschema.v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.reinert.jjschema.Attributes;
+import com.github.reinert.jjschema.JsonSchemaGenerator;
+import com.github.reinert.jjschema.SchemaGeneratorBuilder;
+import com.github.reinert.jjschema.exception.TypeException;
+import com.github.reinert.jjschema.exception.UnavailableVersion;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class FieldsOnlyTest extends TestCase {
+    private final ObjectMapper MAPPER = new ObjectMapper();
+    
+    static class Employee {
+        @Attributes(required = true, minLength = 5, maxLength = 50, description = "Name")
+        private String name;
+
+        public String lastName;
+        
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        private boolean retired;
+
+        public boolean isRetired() {
+            return retired;
+        }
+
+        public void setRetired(boolean retired) {
+            this.retired = retired;
+        }
+    }
+
+    public void testAnnotatedFieldsOnly() throws UnavailableVersion, IOException, TypeException {
+        JsonSchemaGenerator v4generator = SchemaGeneratorBuilder.draftV4Schema()
+            .processFieldsOnly(true)
+            .processAnnotatedOnly(true)
+            .build();
+    
+        JsonNode schemaNode = v4generator.generateSchema(Employee.class);
+    
+        String str = MAPPER.writeValueAsString(schemaNode);
+        Map<String, Object> result = (Map<String, Object>) MAPPER.readValue(str, Map.class);
+        Map props = (Map) result.get(CustomSchemaWrapper.TAG_PROPERTIES);
+        assertEquals(1, props.size());
+    }
+    
+    public void testFieldsOnly() throws UnavailableVersion, IOException, TypeException {
+        JsonSchemaGenerator v4generator = SchemaGeneratorBuilder.draftV4Schema()
+            .processFieldsOnly(true)
+            .build();
+    
+        JsonNode schemaNode = v4generator.generateSchema(Employee.class);
+    
+        String str = MAPPER.writeValueAsString(schemaNode);
+        Map<String, Object> result = (Map<String, Object>) MAPPER.readValue(str, Map.class);
+        Map<String,String> props = (Map) result.get(CustomSchemaWrapper.TAG_PROPERTIES);
+        assertEquals(3, props.size());
+        
+        // Check properties are sorted (default behaviour)
+        String[] keyArr = props.keySet().toArray(new String[0]);
+        assertTrue(Arrays.deepEquals(new String[] {"lastName", "name", "retired"}, keyArr));
+    }
+
+    public void testNoSortedFields() throws UnavailableVersion, IOException, TypeException {
+        JsonSchemaGenerator v4generator = SchemaGeneratorBuilder.draftV4Schema()
+            .processFieldsOnly(true)
+            .sortProperties(false)
+            .build();
+    
+        JsonNode schemaNode = v4generator.generateSchema(Employee.class);
+    
+        String str = MAPPER.writeValueAsString(schemaNode);
+        Map<String, Object> result = (Map<String, Object>) MAPPER.readValue(str, Map.class);
+        Map<String,String> props = (Map) result.get(CustomSchemaWrapper.TAG_PROPERTIES);
+        assertEquals(3, props.size());
+        
+        String[] keyArr = props.keySet().toArray(new String[0]);
+        assertTrue(Arrays.deepEquals(new String[] {"name", "lastName", "retired"}, keyArr));
+    }
+}


### PR DESCRIPTION
 * Added config to control whether:
* we process fields only instead of getters
* only annotated fields/properties are processed
* field/properties are sorted

* Added unit tests for the above (FieldsOnlyTest.java)
* Now throws TypeException when Collections are not parameterized (as expected)