### PR TITLE
Adding to Attributes annotation "alias" property

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/Attributes.java
+++ b/src/main/java/com/github/reinert/jjschema/Attributes.java
@@ -68,4 +68,6 @@ public @interface Attributes {
     long maxLength() default -1L;
     
     boolean readonly() default false;
+
+    String attributeAlias() default "";
 }

--- a/src/main/java/com/github/reinert/jjschema/Attributes.java
+++ b/src/main/java/com/github/reinert/jjschema/Attributes.java
@@ -69,5 +69,5 @@ public @interface Attributes {
     
     boolean readonly() default false;
 
-    String attributeAlias() default "";
+    String alias() default "";
 }

--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
@@ -426,8 +426,22 @@ public abstract class JsonSchemaGenerator {
             requiredNode.add(name);
             prop.remove("selfRequired");
         }
-        if (!schema.has(TAG_PROPERTIES))
+        if (!schema.has(TAG_PROPERTIES)) {
             schema.putObject(TAG_PROPERTIES);
+        }
+
+        // Adding alias capability. Because sometimes renames is actually needed!
+        // Eg: JSON-API JSON Schemas
+        if (field.getDeclaredAnnotations().length > 0) {
+            Attributes declaredAnnotation = field.getDeclaredAnnotation(Attributes.class);
+            if (null != declaredAnnotation ) {
+                String alias = declaredAnnotation.alias();
+                if (alias.length()>0) {
+                    name = alias;
+                }
+            }
+        }
+
         ((ObjectNode) schema.get(TAG_PROPERTIES)).put(name, prop);
     }
 

--- a/src/test/java/com/github/reinert/jjschema/JavaRESTfulTest.java
+++ b/src/test/java/com/github/reinert/jjschema/JavaRESTfulTest.java
@@ -30,12 +30,16 @@ import junit.framework.TestCase;
 
 public class JavaRESTfulTest extends TestCase {
 
-    ObjectWriter om = new ObjectMapper().writerWithDefaultPrettyPrinter();
-    JsonSchemaGenerator v4hyperGenerator = SchemaGeneratorBuilder.draftV4HyperSchema().setAutoPutSchemaVersion(false).build();
+    private ObjectWriter om = new ObjectMapper().writerWithDefaultPrettyPrinter();
+    private JsonSchemaGenerator v4hyperGenerator = SchemaGeneratorBuilder.draftV4HyperSchema().setAutoPutSchemaVersion(false).build();
 
     public void testHyperSchema() throws JsonProcessingException, TypeException  {
         JsonNode userHyperSchema = v4hyperGenerator.generateSchema(User.class);
-        //System.out.println(om.writeValueAsString(userSchema));
+
+        //Testing property aliasing
+        assertNotNull(userHyperSchema.get("properties").get("gender"));
+
+        //Testing property values property serialized.
         assertEquals("image/jpg", userHyperSchema.get("properties").get("photo").get("mediaType").asText());
         assertEquals("base64", userHyperSchema.get("properties").get("photo").get("binaryEncoding").asText());
 

--- a/src/test/java/com/github/reinert/jjschema/model/User.java
+++ b/src/test/java/com/github/reinert/jjschema/model/User.java
@@ -31,7 +31,7 @@ public class User {
     @Attributes(required = true, description = "User's name")
     private String name;
 
-    @Attributes(description = "User's sex", enums = {"M", "F"})
+    @Attributes(alias = "gender", description = "User's sex", enums = {"M", "F"})
     @Nullable
     private char sex;
 


### PR DESCRIPTION
Allow aliasing of Fields when using the `@Attributes` annotation.

My use-case is doing JSON Schema mapping on JSONAPI data. 

JSONAPI properties require to follow the dash convention, for instance I needed to have `conversation-id` instead of `conversationId` on the generated schema.