### PR TITLE
Bug Fix: fieldName could be empty or null.

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
+++ b/src/main/java/com/github/reinert/jjschema/v1/CustomSchemaWrapper.java
@@ -188,7 +188,7 @@ public class CustomSchemaWrapper extends SchemaWrapper implements Iterable<Prope
             }
         }
 
-        if (fieldName == null) {
+        if (fieldName == null || "".equals(fieldName)) {
             return null;
         }
 


### PR DESCRIPTION
Updated the guard clause to check the validity of the fieldName.

### Example:
If a _class_ has method with signature `public List<String> get(Object key)`, the `methodName` would be returned as `get`. When the following block is executed, it would return the `fieldName` as empty string.

```
if (methodName.startsWith(prefix)) {
    fieldName = methodName.substring(prefix.length());
}
```
So when `fieldName.substring(..)` is executed, it would throw `java.lang.StringIndexOutOfBoundsException` exception.