### PR TITLE
adding mapping ZonedDateTime => string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.reinert</groupId>
     <artifactId>jjschema</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JJSchema</name>
@@ -35,7 +35,7 @@
         <connection>scm:git:ssh://github.com/reinert/JJSchema.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/reinert/JJSchema.git</developerConnection>
         <url>https://github.com/reinert/JJSchema</url>
-        <tag>1.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <connection>scm:git:ssh://github.com/reinert/JJSchema.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/reinert/JJSchema.git</developerConnection>
         <url>https://github.com/reinert/JJSchema</url>
-        <tag>HEAD</tag>
+        <tag>1.1</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.reinert</groupId>
     <artifactId>jjschema</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>JJSchema</name>
@@ -35,7 +35,7 @@
         <connection>scm:git:ssh://github.com/reinert/JJSchema.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/reinert/JJSchema.git</developerConnection>
         <url>https://github.com/reinert/JJSchema</url>
-        <tag>HEAD</tag>
+        <tag>1.1</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.reinert</groupId>
     <artifactId>jjschema</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>JJSchema</name>

--- a/release.sh
+++ b/release.sh
@@ -13,8 +13,8 @@ if [ -n "$1" ] && [ -n "$2" ]; then
   # deploy
   mvn clean deploy -Prelease
   # tag
-  git tag -a JJSchema-$1 -m "JJSchema v$1"
-  git push origin JJSchema-$1
+  git tag -a JJSchema-1-$1 -m "JJSchema-1 v$1"
+  git push origin JJSchema-1$1
   # update version to next snapshot
   mvn versions:set -DnewVersion=$2
   mvn versions:commit

--- a/src/main/java/com/github/reinert/jjschema/SimpleTypeMappings.java
+++ b/src/main/java/com/github/reinert/jjschema/SimpleTypeMappings.java
@@ -20,6 +20,7 @@ package com.github.reinert.jjschema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.ZonedDateTime;
 import java.util.AbstractCollection;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -55,7 +56,8 @@ public enum SimpleTypeMappings {
     CHAR(Character.class, "string"),
     CHARSEQUENCE(CharSequence.class, "string"),
     STRING(String.class, "string"),
-    UUID(UUID.class, "string");
+    UUID(UUID.class, "string"),
+    ZONEDDATETIME(ZonedDateTime.class,"string");
 
     private static final Map<Class<?>, String> MAPPINGS;
 


### PR DESCRIPTION
Allow the usage of java type "java.time.ZonedDateTime as a type for a field.

@Attributes(description = "date with timezone")
private ZonedDateTime myDate;
=>
"myDate": {
  "type": "string",
  "description": "date with timezone"
}

Otherwise, we get an error at execution as the ZonedDateTime Class contains a simple generic "get" method :

    private String processPropertyName() {
        return (field == null) ? firstToLowerCase(method.getName()
                .replace("get", "")) : field.getName();
    }

Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 0
	at java.lang.String.charAt(String.java:658)
	at com.github.reinert.jjschema.v1.PropertyWrapper.firstToLowerCase(PropertyWrapper.java:370)
