### PR TITLE
adding mapping for ZonedDateTime, LocalDate and Instant

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/SimpleTypeMappings.java
+++ b/src/main/java/com/github/reinert/jjschema/SimpleTypeMappings.java
@@ -20,6 +20,9 @@ package com.github.reinert.jjschema;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.AbstractCollection;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -55,7 +58,10 @@ public enum SimpleTypeMappings {
     CHAR(Character.class, "string"),
     CHARSEQUENCE(CharSequence.class, "string"),
     STRING(String.class, "string"),
-    UUID(UUID.class, "string");
+    UUID(UUID.class, "string"),
+    ZONEDDATETIME(ZonedDateTime.class,"string"),
+    LOCALDATE(LocalDate.class,"string"),
+    INSTANT(Instant.class,"string");
 
     private static final Map<Class<?>, String> MAPPINGS;
 


### PR DESCRIPTION
Allow the usage of java type "java.time.ZonedDateTime" as a type for a field, mapped to json primitive "string".

(new "clean" pull request : adding extra types java.time.LocalDate and java.time.Instant, mapped to json primitive string)

@Attributes(description = "date with timezone")
private ZonedDateTime myDate;
=>
"myDate": {
"type": "string",
"description": "date with timezone"
}

Otherwise, we get an error at execution as the ZonedDateTime Class contains a simple generic "get" method :

private String processPropertyName() {
    return (field == null) ? firstToLowerCase(method.getName()
            .replace("get", "")) : field.getName();
}

Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 0
at java.lang.String.charAt(String.java:658)
at com.github.reinert.jjschema.v1.PropertyWrapper.firstToLowerCase(PropertyWrapper.java:370)
