### PR TITLE
Ignores a number of fields in a class.

### DIFF
--- a/src/main/java/com/github/reinert/jjschema/HyperSchemaGeneratorV4.java
+++ b/src/main/java/com/github/reinert/jjschema/HyperSchemaGeneratorV4.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Context;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.Iterator;
@@ -243,6 +244,10 @@ public class HyperSchemaGeneratorV4 extends JsonSchemaGenerator {
         ArrayNode links = schema.putArray("links");
 
         for (Method method : type.getDeclaredMethods()) {
+            int modifiers = method.getModifiers();
+            if (method.isSynthetic() || method.isBridge() || Modifier.isStatic(modifiers)) {
+                continue;
+            }
             try {
                 ObjectNode link = generateLink(method);
                 if ("GET".equals(link.get("method").asText()) && "#".equals(link.get("href").asText())) {

--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
@@ -556,6 +556,13 @@ public abstract class JsonSchemaGenerator {
             if (isGetter(method)) {
                 boolean hasField = false;
                 for (Field field : fields) {
+
+                    int fieldModifiers = field.getModifiers();
+
+                    if (field.isSynthetic() || field.isEnumConstant() || Modifier.isStatic(fieldModifiers) || Modifier.isTransient(fieldModifiers)) {
+                        continue;
+                    }
+
                     String name = getNameFromGetter(method);
                     Attributes attribs = field.getAnnotation(Attributes.class);
                     boolean process = true;

--- a/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
+++ b/src/main/java/com/github/reinert/jjschema/JsonSchemaGenerator.java
@@ -21,6 +21,7 @@ package com.github.reinert.jjschema;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -590,6 +591,13 @@ public abstract class JsonSchemaGenerator {
         // get fields
         for (Field field : fields) {
             Class<?> declaringClass = field.getDeclaringClass();
+
+            int fieldModifiers = field.getModifiers();
+
+            if (field.isSynthetic() || field.isEnumConstant() || Modifier.isStatic(fieldModifiers) || Modifier.isTransient(fieldModifiers)) {
+                continue;
+            }
+
             if (declaringClass.equals(Object.class)
                     || Collection.class.isAssignableFrom(declaringClass)) {
                 continue;


### PR DESCRIPTION
Some fields (such as enum constants, static or synthetic fields)
should never be picked up by the generator. The current behavior leads
to unexpected side effects (e.g. some tests fail when running under
coverage because the coverage agent adds transient static fields to
all instrumented classes). This change skips such fields.